### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "git@github.com:SKB-CGN/ioBroker.mywallbox.git"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3"
   },


### PR DESCRIPTION
adapter-core 3.x.x is know to fail during install on node 14 as npm 6 does not install peerDependencies.
So this adapter requires  node 16 or newer